### PR TITLE
Fixed tool comment parsing (fixes #2)

### DIFF
--- a/commands/postProcessor/line.py
+++ b/commands/postProcessor/line.py
@@ -25,7 +25,7 @@ class Line():
     
     _GCODES_RE: Final = re.compile(r"G([0-9]+(?:\.[0-9]*)?)")
 
-    _TOOL_COMMENT_REG: Final = re.compile(r"\((T[0-9])+\s")
+    _TOOL_COMMENT_REG: Final = re.compile(r"\(T[0-9]+\s.*\)$")
 
     _COMMENT_REG: Final = re.compile(r"^(?:\s*)\((.*)\)(?:\s*)$")
 

--- a/commands/postProcessor/settings/settings.py
+++ b/commands/postProcessor/settings/settings.py
@@ -74,7 +74,7 @@ class Settings(Constants, metaclass=_SettingsMeta):
         if attr and attr.count > 0:
             try:
                 cls._items = json.loads(attr.itemByName(Const.ATTR_GROUP, Const.ATTR_NAME).value)
-                if cls._items(Constants.VERSION) is not None and cls._items[Constants.VERSION] == config.SETTINGS_VERSION:
+                if cls._items.get(Constants.VERSION) is not None and cls._items[Constants.VERSION] == config.SETTINGS_VERSION:
                     return  # settings are valid for this version
             except Exception:
                 pass


### PR DESCRIPTION
The parsing of the tool comment expected a tool number with only 1 digit. This fixes that issue.