### PR TITLE
Add automated Fusion plugin releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+name: Create Fusion Plugin Release
+
+run-name: >-
+  ${{ inputs.dry_run && 'Dry run' || 'Release' }}
+  v${{ inputs.version }} from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: SemVer without a leading v, for example 0.9.2-beta.1
+        required: true
+        type: string
+      dry_run:
+        description: Build and validate artifacts without creating a tag or release
+        required: true
+        default: true
+        type: boolean
+      publish_stable_from_non_main:
+        description: Explicitly allow a stable release when the selected ref is not main
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      ASSET_NAME: Makera-Community-Fusion-Plugin-v${{ inputs.version }}.zip
+    steps:
+      - name: Check out selected source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Validate release policy
+        id: policy
+        shell: bash
+        run: |
+          python scripts/build_release.py --version "$VERSION" --output dist
+
+          policy_args=(--version "$VERSION" --ref "$GITHUB_REF_NAME")
+          if [[ "${{ inputs.publish_stable_from_non_main }}" == "true" ]]; then
+            policy_args+=(--publish-stable-from-non-main)
+          fi
+          prerelease="$(python -m scripts.release_policy "${policy_args[@]}")"
+
+          if [[ "$prerelease" == "false" && "$GITHUB_REF_NAME" != "main" ]]; then
+            echo "::warning::Publishing a stable release from non-main ref $GITHUB_REF_NAME"
+          fi
+
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "Release policy: ref=$GITHUB_REF_NAME prerelease=$prerelease dry_run=${{ inputs.dry_run }}"
+
+      - name: Run host tests
+        run: pytest --cov=commands --cov-report=term
+
+      - name: Verify packaged versions and contents
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import zipfile
+
+          archive = "dist/" + os.environ["ASSET_NAME"]
+          expected = os.environ["VERSION"]
+          with zipfile.ZipFile(archive) as package:
+              names = package.namelist()
+              manifest = json.loads(package.read("Makera Community/Makera Community.manifest"))
+              config = package.read("Makera Community/config.py").decode()
+
+          assert manifest["version"] == expected
+          assert f"PLUGIN_VERSION = '{expected}'" in config
+          assert "DEBUG = False" in config
+          assert not any(
+              "Tests/" in name
+              or "__pycache__" in name
+              or name.endswith("settings.settings")
+              for name in names
+          )
+          PY
+          (cd dist && sha256sum --check "$ASSET_NAME.sha256")
+
+      - name: Upload dry-run artifacts
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Makera-Community-Fusion-Plugin-v${{ inputs.version }}-dry-run
+          path: |
+            dist/${{ env.ASSET_NAME }}
+            dist/${{ env.ASSET_NAME }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Refuse to overwrite an existing tag
+        if: ${{ inputs.dry_run == false }}
+        shell: bash
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists" >&2
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.policy.outputs.prerelease }}
+        shell: bash
+        run: |
+          args=(
+            release create "v$VERSION"
+            "dist/$ASSET_NAME"
+            "dist/$ASSET_NAME.sha256"
+            --target "$GITHUB_SHA"
+            --title "Makera Community Fusion Plugin v$VERSION"
+            --generate-notes
+          )
+          if [[ "$PRERELEASE" == "true" ]]; then
+            args+=(--prerelease --latest=false)
+          else
+            args+=(--latest)
+          fi
+          gh "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Create Fusion Plugin Release
 
 run-name: >-
   ${{ inputs.dry_run && 'Dry run' || 'Release' }}
-  v${{ inputs.version }} from ${{ github.ref_name }}
+  v${{ inputs.version }} from ${{ inputs.source_ref }}
 
 on:
   workflow_dispatch:
@@ -10,6 +10,11 @@ on:
       version:
         description: SemVer without a leading v, for example 0.9.2-beta.1
         required: true
+        type: string
+      source_ref:
+        description: Branch, tag, or commit to package
+        required: true
+        default: dev
         type: string
       dry_run:
         description: Build and validate artifacts without creating a tag or release
@@ -38,6 +43,15 @@ jobs:
     steps:
       - name: Check out selected source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Record selected source
+        id: source
+        shell: bash
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Building source ${{ inputs.source_ref }} at $(git rev-parse HEAD)"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -54,18 +68,18 @@ jobs:
         run: |
           python scripts/build_release.py --version "$VERSION" --output dist
 
-          policy_args=(--version "$VERSION" --ref "$GITHUB_REF_NAME")
+          policy_args=(--version "$VERSION" --ref "${{ inputs.source_ref }}")
           if [[ "${{ inputs.publish_stable_from_non_main }}" == "true" ]]; then
             policy_args+=(--publish-stable-from-non-main)
           fi
           prerelease="$(python -m scripts.release_policy "${policy_args[@]}")"
 
-          if [[ "$prerelease" == "false" && "$GITHUB_REF_NAME" != "main" ]]; then
-            echo "::warning::Publishing a stable release from non-main ref $GITHUB_REF_NAME"
+          if [[ "$prerelease" == "false" && "${{ inputs.source_ref }}" != "main" ]]; then
+            echo "::warning::Publishing a stable release from non-main ref ${{ inputs.source_ref }}"
           fi
 
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
-          echo "Release policy: ref=$GITHUB_REF_NAME prerelease=$prerelease dry_run=${{ inputs.dry_run }}"
+          echo "Release policy: ref=${{ inputs.source_ref }} prerelease=$prerelease dry_run=${{ inputs.dry_run }}"
 
       - name: Run host tests
         run: pytest --cov=commands --cov-report=term
@@ -128,7 +142,7 @@ jobs:
             release create "v$VERSION"
             "dist/$ASSET_NAME"
             "dist/$ASSET_NAME.sha256"
-            --target "$GITHUB_SHA"
+            --target "${{ steps.source.outputs.sha }}"
             --title "Makera Community Fusion Plugin v$VERSION"
             --generate-notes
           )

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ Tests/*.f3d
 __pycache__
 .coverage
 htmlcov/
+dist/
 TODO.md

--- a/README.md
+++ b/README.md
@@ -21,20 +21,16 @@ This plugin was heavily inspired by Tim Patersons [PostProcessAll](https://githu
 - [Makera post-processor](https://github.com/Carvera-Community/Carvera_Community_Profiles/tree/main/CAM_Post_Processors) (or a post-processor for your CNC-machine)
 
 ## Installation
-This plugin follows the normal plugin-installation procedure of a local add-in for Fusion.
-1. Clone the repository:
+Install a published release rather than cloning the development repository:
 
-Using a git client you start by downloading this repository into a folder of your choice:
+1. Open the [latest release](https://github.com/Carvera-Community/Carvera_Community_FusionPlugin/releases/latest).
+2. Download `Source code (zip)` from the release's **Assets** section.
+3. Extract the archive to a permanent folder. Do not run the add-in directly
+   from the downloaded archive or a temporary extraction directory.
+4. Confirm that the extracted add-in folder contains
+   `Makera Community.manifest`.
 
-```bash
-# SSH (recommended if you have SSH keys configured):
-git clone git@github.com:Carvera-Community/CarveraCommunity_FusionPlugin.git "Makera Community"
-
-# OR HTTPS:
-git clone https://github.com/Carvera-Community/CarveraCommunity_FusionPlugin.git "Makera Community"
-
-```
-Follow the generic instructions to install add-ins into Fusion 360:
+Then follow Fusion's normal procedure for installing a local add-in:
 
 <img src="resources/readme/installation/step1.png">
 
@@ -47,7 +43,8 @@ Follow the generic instructions to install add-ins into Fusion 360:
 
 <img src="resources/readme/installation/step4.png">
 
-4. Choose 'Script or add-in from device' and select the folder that you just cloned the repo to (the folder with the Makera Community.manifest file)
+4. Choose 'Script or add-in from device' and select the extracted folder that
+   contains the `Makera Community.manifest` file.
 
 <img src="resources/readme/installation/step5.png">
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This plugin was heavily inspired by Tim Patersons [PostProcessAll](https://githu
 Install a published release rather than cloning the development repository:
 
 1. Open the [latest release](https://github.com/Carvera-Community/Carvera_Community_FusionPlugin/releases/latest).
-2. Download `Source code (zip)` from the release's **Assets** section.
+2. Download `Makera-Community-Fusion-Plugin-vX.Y.Z.zip` from the release's
+   **Assets** section. Do not download GitHub's automatically generated source
+   archive.
 3. Extract the archive to a permanent folder. Do not run the add-in directly
    from the downloaded archive or a temporary extraction directory.
 4. Confirm that the extracted add-in folder contains

--- a/Tests/test_release_build.py
+++ b/Tests/test_release_build.py
@@ -1,0 +1,91 @@
+import hashlib
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "release_builder",
+    ROOT / "scripts" / "build_release.py",
+)
+builder = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(builder)
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.0.0", "0.9.2-beta.1", "10.20.30-rc.2", "1.0.0+build.7"],
+)
+def test_validate_version_accepts_supported_semver(version):
+    assert builder.validate_version(version) == version
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["v1.0.0", "1.0", "01.0.0", "1.0.0-beta..1", "1.0.0-beta.01"],
+)
+def test_validate_version_rejects_unsupported_versions(version):
+    with pytest.raises(ValueError, match="SemVer"):
+        builder.validate_version(version)
+
+
+def test_build_release_stamps_only_packaged_plugin_versions(tmp_path):
+    output = tmp_path / "dist"
+    source_manifest = (ROOT / "Makera Community.manifest").read_bytes()
+    source_config = (ROOT / "config.py").read_bytes()
+
+    archive = builder.build_release(ROOT, output, "2.3.4-beta.5")
+
+    assert archive.name == "Makera-Community-Fusion-Plugin-v2.3.4-beta.5.zip"
+    with zipfile.ZipFile(archive) as package:
+        names = set(package.namelist())
+        manifest = json.loads(
+            package.read("Makera Community/Makera Community.manifest")
+        )
+        config = package.read("Makera Community/config.py").decode()
+
+    assert manifest["version"] == "2.3.4-beta.5"
+    assert "PLUGIN_VERSION = '2.3.4-beta.5'" in config
+    assert "DEBUG = False" in config
+    assert "Makera Community/Makera Community.py" in names
+    assert any(name.startswith("Makera Community/commands/") for name in names)
+    assert any(name.startswith("Makera Community/lib/") for name in names)
+    assert not any("Tests/" in name for name in names)
+    assert not any("__pycache__" in name or name.endswith(".pyc") for name in names)
+    assert not any(name.endswith("settings.settings") for name in names)
+    assert (ROOT / "Makera Community.manifest").read_bytes() == source_manifest
+    assert (ROOT / "config.py").read_bytes() == source_config
+
+    checksum = archive.with_suffix(".zip.sha256").read_text().split()[0]
+    assert checksum == hashlib.sha256(archive.read_bytes()).hexdigest()
+
+
+def test_build_release_is_reproducible(tmp_path):
+    first = builder.build_release(ROOT, tmp_path / "first", "1.2.3")
+    second = builder.build_release(ROOT, tmp_path / "second", "1.2.3")
+
+    assert first.read_bytes() == second.read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("version", "ref_name", "allow_stable", "expected"),
+    [
+        ("1.0.0", "main", False, False),
+        ("1.0.0-beta.1", "main", True, True),
+        ("1.0.0", "dev", False, True),
+        ("1.0.0", "feature/test", False, True),
+        ("1.0.0", "dev", True, False),
+        ("1.0.0-beta.1", "dev", True, True),
+    ],
+)
+def test_release_policy_defaults_non_main_to_prerelease(
+    version,
+    ref_name,
+    allow_stable,
+    expected,
+):
+    assert builder.is_prerelease(version, ref_name, allow_stable) is expected

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,46 @@
+# Creating a release
+
+Releases are built by the `Create Fusion Plugin Release` GitHub Actions
+workflow. The workflow stamps and packages the add-in without changing the
+source files on the selected branch.
+
+## Dry run
+
+1. Open **Actions** in GitHub.
+2. Select **Create Fusion Plugin Release**.
+3. Select **Run workflow** and choose the source branch.
+4. Enter a SemVer version without a leading `v`, such as `0.9.2-beta.1`.
+5. Leave **Build and validate artifacts without creating a tag or release**
+   enabled.
+6. Run the workflow.
+7. Download the dry-run artifact from the completed workflow run and inspect
+   the zip and checksum.
+
+A dry run creates neither a Git tag nor a GitHub release. Its artifact is kept
+for seven days.
+
+## Publish
+
+Repeat the dry run with its checkbox disabled. The workflow creates tag
+`vX.Y.Z`, a GitHub release named `Makera Community Fusion Plugin vX.Y.Z`, the
+installable zip, and its SHA-256 checksum.
+
+Versions containing a prerelease suffix, such as `-beta.1` or `-rc.1`, are
+always published as prereleases. A stable version selected from any ref other
+than `main` also defaults to prerelease. Publishing it as stable requires the
+explicit **allow a stable release when the selected ref is not main** option.
+
+The workflow refuses to overwrite an existing tag.
+
+## Version boundaries
+
+The release builder stamps exactly these packaged values:
+
+- `version` in `Makera Community.manifest`
+- `PLUGIN_VERSION` in `config.py`
+
+It also forces packaged builds to `DEBUG = False` and excludes local
+`settings.settings` files, bytecode, tests, and development-only files.
+
+It does not change `SETTINGS_VERSION`, translation `fileVersion` values, UI
+catalog schema versions, or referenced post-processor versions.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,12 +8,14 @@ source files on the selected branch.
 
 1. Open **Actions** in GitHub.
 2. Select **Create Fusion Plugin Release**.
-3. Select **Run workflow** and choose the source branch.
-4. Enter a SemVer version without a leading `v`, such as `0.9.2-beta.1`.
-5. Leave **Build and validate artifacts without creating a tag or release**
+3. Select **Run workflow**.
+4. Enter the branch, tag, or commit to package in **source ref**. The default
+   is `dev`.
+5. Enter a SemVer version without a leading `v`, such as `0.9.2-beta.1`.
+6. Leave **Build and validate artifacts without creating a tag or release**
    enabled.
-6. Run the workflow.
-7. Download the dry-run artifact from the completed workflow run and inspect
+7. Run the workflow.
+8. Download the dry-run artifact from the completed workflow run and inspect
    the zip and checksum.
 
 A dry run creates neither a Git tag nor a GitHub release. Its artifact is kept

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Development and release automation helpers."""

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Build a version-stamped Fusion add-in release archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import zipfile
+from pathlib import Path
+
+
+ADDIN_FOLDER = "Makera Community"
+ARCHIVE_PREFIX = "Makera-Community-Fusion-Plugin-v"
+SEMVER = re.compile(
+    r"^(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+ROOT_FILES = (
+    "Makera Community.py",
+    "Makera Community.manifest",
+    "Makera Community.svg",
+    "config.py",
+    "README.md",
+)
+ROOT_DIRECTORIES = ("commands", "lib")
+IGNORED_NAMES = {".DS_Store", "__pycache__"}
+
+
+def validate_version(version: str) -> str:
+    if not SEMVER.fullmatch(version):
+        raise ValueError(
+            "version must be SemVer without a leading 'v', for example "
+            "0.9.2 or 0.9.2-beta.1"
+        )
+    prerelease = version.split("+", 1)[0].partition("-")[2]
+    if prerelease and any(
+        identifier.isdigit()
+        and len(identifier) > 1
+        and identifier.startswith("0")
+        for identifier in prerelease.split(".")
+    ):
+        raise ValueError("numeric SemVer prerelease identifiers cannot have leading zeroes")
+    return version
+
+
+def is_prerelease(
+    version: str,
+    ref_name: str,
+    publish_stable_from_non_main: bool = False,
+) -> bool:
+    validate_version(version)
+    if "-" in version.split("+", 1)[0]:
+        return True
+    if ref_name == "main":
+        return False
+    return not publish_stable_from_non_main
+
+
+def stamp_manifest(path: Path, version: str) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data.get("version"), str):
+        raise ValueError(f"{path}: missing string version field")
+    data["version"] = version
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def stamp_config(path: Path, version: str) -> None:
+    source = path.read_text(encoding="utf-8")
+    stamped, version_replacements = re.subn(
+        r"^PLUGIN_VERSION\s*=\s*(['\"]).*?\1\s*$",
+        f"PLUGIN_VERSION = '{version}'",
+        source,
+        flags=re.MULTILINE,
+    )
+    stamped, debug_replacements = re.subn(
+        r"^DEBUG\s*=\s*(?:True|False)\s*$",
+        "DEBUG = False",
+        stamped,
+        flags=re.MULTILINE,
+    )
+    if version_replacements != 1:
+        raise ValueError(
+            f"{path}: expected exactly one PLUGIN_VERSION assignment, "
+            f"found {version_replacements}"
+        )
+    if debug_replacements != 1:
+        raise ValueError(
+            f"{path}: expected exactly one DEBUG assignment, "
+            f"found {debug_replacements}"
+        )
+    path.write_text(stamped, encoding="utf-8")
+
+
+def read_stamped_versions(addin_dir: Path) -> tuple[str, str]:
+    manifest = json.loads(
+        (addin_dir / "Makera Community.manifest").read_text(encoding="utf-8")
+    )
+    config = (addin_dir / "config.py").read_text(encoding="utf-8")
+    match = re.search(
+        r"^PLUGIN_VERSION\s*=\s*(['\"])(?P<version>.*?)\1\s*$",
+        config,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        raise ValueError("staged config.py has no readable PLUGIN_VERSION")
+    return manifest["version"], match.group("version")
+
+
+def copy_runtime_files(project_root: Path, addin_dir: Path) -> None:
+    for relative in ROOT_FILES:
+        source = project_root / relative
+        if not source.is_file():
+            raise FileNotFoundError(f"required release file is missing: {source}")
+        shutil.copy2(source, addin_dir / relative)
+
+    for relative in ROOT_DIRECTORIES:
+        source = project_root / relative
+        if not source.is_dir():
+            raise FileNotFoundError(f"required release directory is missing: {source}")
+        shutil.copytree(
+            source,
+            addin_dir / relative,
+            ignore=shutil.ignore_patterns(
+                "__pycache__",
+                "*.pyc",
+                ".DS_Store",
+                "settings.settings",
+            ),
+        )
+
+
+def write_reproducible_zip(addin_dir: Path, archive: Path) -> None:
+    if archive.exists():
+        archive.unlink()
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as output:
+        for source in sorted(path for path in addin_dir.rglob("*") if path.is_file()):
+            relative = source.relative_to(addin_dir.parent)
+            info = zipfile.ZipInfo(str(relative).replace("\\", "/"))
+            info.date_time = (1980, 1, 1, 0, 0, 0)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            output.writestr(info, source.read_bytes())
+
+
+def build_release(project_root: Path, output_dir: Path, version: str) -> Path:
+    version = validate_version(version)
+    staging_root = output_dir / "staging"
+    addin_dir = staging_root / ADDIN_FOLDER
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+    addin_dir.mkdir(parents=True)
+
+    copy_runtime_files(project_root, addin_dir)
+    stamp_manifest(addin_dir / "Makera Community.manifest", version)
+    stamp_config(addin_dir / "config.py", version)
+
+    manifest_version, config_version = read_stamped_versions(addin_dir)
+    if manifest_version != version or config_version != version:
+        raise ValueError(
+            "release version mismatch: "
+            f"manifest={manifest_version!r}, config={config_version!r}, "
+            f"requested={version!r}"
+        )
+
+    archive = output_dir / f"{ARCHIVE_PREFIX}{version}.zip"
+    write_reproducible_zip(addin_dir, archive)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    archive.with_suffix(".zip.sha256").write_text(
+        f"{digest}  {archive.name}\n",
+        encoding="utf-8",
+    )
+    return archive
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, default=Path("dist"))
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    archive = build_release(
+        args.project_root.resolve(),
+        args.output.resolve(),
+        args.version,
+    )
+    print(archive)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_policy.py
+++ b/scripts/release_policy.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Resolve whether a requested release must be a prerelease."""
+
+from __future__ import annotations
+
+import argparse
+
+from scripts.build_release import is_prerelease
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--publish-stable-from-non-main", action="store_true")
+    args = parser.parse_args()
+
+    print(
+        "true"
+        if is_prerelease(
+            args.version,
+            args.ref,
+            args.publish_stable_from_non_main,
+        )
+        else "false"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add automated packaging and release support for the Fusion plugin.

- Build a clean, version-stamped installation archive.
- Add SHA-256 verification.
- Exclude tests, local settings, bytecode, and development files.
- Disable debug logging in packaged releases.
- Add dry-run support.
- Select the packaged source through an explicit `source_ref`.
- Default non-main builds to prerelease.
- Require explicit approval for stable releases from non-main sources.
- Update installation instructions to use curated release assets.
