### PR TITLE
Pin packaged README images to release sources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,10 @@ jobs:
         id: policy
         shell: bash
         run: |
-          python scripts/build_release.py --version "$VERSION" --output dist
+          python scripts/build_release.py \
+            --version "$VERSION" \
+            --source-revision "${{ steps.source.outputs.sha }}" \
+            --output dist
 
           policy_args=(--version "$VERSION" --ref "${{ inputs.source_ref }}")
           if [[ "${{ inputs.publish_stable_from_non_main }}" == "true" ]]; then
@@ -117,10 +120,13 @@ jobs:
               names = package.namelist()
               manifest = json.loads(package.read("Makera Community/Makera Community.manifest"))
               config = package.read("Makera Community/config.py").decode()
+              readme = package.read("Makera Community/README.md").decode()
 
           assert manifest["version"] == expected
           assert f"PLUGIN_VERSION = '{expected}'" in config
           assert "DEBUG = False" in config
+          assert 'src="resources/' not in readme
+          assert "raw.githubusercontent.com" in readme
           assert not any(
               "Tests/" in name
               or "__pycache__" in name

--- a/Tests/test_release_build.py
+++ b/Tests/test_release_build.py
@@ -53,7 +53,12 @@ def test_build_release_stamps_only_packaged_plugin_versions(tmp_path):
     source_manifest = (ROOT / "Makera Community.manifest").read_bytes()
     source_config = (ROOT / "config.py").read_bytes()
 
-    archive = builder.build_release(ROOT, output, "2.3.4-beta.5")
+    archive = builder.build_release(
+        ROOT,
+        output,
+        "2.3.4-beta.5",
+        source_revision="0123456789abcdef",
+    )
 
     assert archive.name == "Makera-Community-Fusion-Plugin-v2.3.4-beta.5.zip"
     with zipfile.ZipFile(archive) as package:
@@ -62,10 +67,17 @@ def test_build_release_stamps_only_packaged_plugin_versions(tmp_path):
             package.read("Makera Community/Makera Community.manifest")
         )
         config = package.read("Makera Community/config.py").decode()
+        readme = package.read("Makera Community/README.md").decode()
 
     assert manifest["version"] == "2.3.4-beta.5"
     assert "PLUGIN_VERSION = '2.3.4-beta.5'" in config
     assert "DEBUG = False" in config
+    assert 'src="resources/' not in readme
+    assert (
+        "https://raw.githubusercontent.com/Carvera-Community/"
+        "Carvera_Community_FusionPlugin/0123456789abcdef/"
+        "resources/readme/installation/step1.png"
+    ) in readme
     assert "Makera Community/Makera Community.py" in names
     assert any(name.startswith("Makera Community/commands/") for name in names)
     assert any(name.startswith("Makera Community/lib/") for name in names)
@@ -74,6 +86,7 @@ def test_build_release_stamps_only_packaged_plugin_versions(tmp_path):
     assert not any(name.endswith("settings.settings") for name in names)
     assert (ROOT / "Makera Community.manifest").read_bytes() == source_manifest
     assert (ROOT / "config.py").read_bytes() == source_config
+    assert 'src="resources/' in (ROOT / "README.md").read_text()
 
     checksum = archive.with_suffix(".zip.sha256").read_text().split()[0]
     assert checksum == hashlib.sha256(archive.read_bytes()).hexdigest()
@@ -84,6 +97,14 @@ def test_build_release_is_reproducible(tmp_path):
     second = builder.build_release(ROOT, tmp_path / "second", "1.2.3")
 
     assert first.read_bytes() == second.read_bytes()
+
+
+def test_readme_rewrite_rejects_an_invalid_source_revision(tmp_path):
+    readme = tmp_path / "README.md"
+    readme.write_text('<img src="resources/image.png">', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source revision"):
+        builder.rewrite_readme_images(readme, "invalid revision")
 
 
 @pytest.mark.parametrize(

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,5 +50,9 @@ The release builder stamps exactly these packaged values:
 It also forces packaged builds to `DEBUG = False` and excludes local
 `settings.settings` files, bytecode, tests, and development-only files.
 
+Relative README image links are rewritten in the package to absolute GitHub
+raw-content URLs pinned to the exact source commit. Images therefore work when
+the packaged README is opened locally and remain tied to the released source.
+
 It does not change `SETTINGS_VERSION`, translation `fileVersion` values, UI
 catalog schema versions, or referenced post-processor versions.

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -10,10 +10,15 @@ import re
 import shutil
 import zipfile
 from pathlib import Path
+from urllib.parse import quote
 
 
 ADDIN_FOLDER = "Makera Community"
 ARCHIVE_PREFIX = "Makera-Community-Fusion-Plugin-v"
+RAW_CONTENT_ROOT = (
+    "https://raw.githubusercontent.com/"
+    "Carvera-Community/Carvera_Community_FusionPlugin"
+)
 SEMVER = re.compile(
     r"^(?:0|[1-9][0-9]*)\."
     r"(?:0|[1-9][0-9]*)\."
@@ -118,6 +123,28 @@ def read_stamped_versions(addin_dir: Path) -> tuple[str, str]:
     return manifest["version"], match.group("version")
 
 
+def rewrite_readme_images(path: Path, source_revision: str) -> int:
+    if not source_revision or any(character.isspace() for character in source_revision):
+        raise ValueError("source revision must be non-empty and contain no whitespace")
+    source = path.read_text(encoding="utf-8")
+    base = f"{RAW_CONTENT_ROOT}/{quote(source_revision, safe='')}/resources/"
+    rewritten, replacements = re.subn(
+        r"(?P<prefix><img\s+[^>]*src=['\"])resources/(?P<path>[^'\"]+)(?P<suffix>['\"])",
+        lambda match: (
+            match.group("prefix")
+            + base
+            + quote(match.group("path"), safe="/")
+            + match.group("suffix")
+        ),
+        source,
+        flags=re.IGNORECASE,
+    )
+    if replacements == 0:
+        raise ValueError(f"{path}: no relative README image links were found")
+    path.write_text(rewritten, encoding="utf-8")
+    return replacements
+
+
 def copy_runtime_files(project_root: Path, addin_dir: Path) -> None:
     for relative in ROOT_FILES:
         source = project_root / relative
@@ -154,7 +181,12 @@ def write_reproducible_zip(addin_dir: Path, archive: Path) -> None:
             output.writestr(info, source.read_bytes())
 
 
-def build_release(project_root: Path, output_dir: Path, version: str) -> Path:
+def build_release(
+    project_root: Path,
+    output_dir: Path,
+    version: str,
+    source_revision: str = "main",
+) -> Path:
     version = validate_version(version)
     staging_root = output_dir / "staging"
     addin_dir = staging_root / ADDIN_FOLDER
@@ -165,6 +197,7 @@ def build_release(project_root: Path, output_dir: Path, version: str) -> Path:
     copy_runtime_files(project_root, addin_dir)
     stamp_manifest(addin_dir / "Makera Community.manifest", version)
     stamp_config(addin_dir / "config.py", version)
+    rewrite_readme_images(addin_dir / "README.md", source_revision)
 
     manifest_version, config_version = read_stamped_versions(addin_dir)
     if manifest_version != version or config_version != version:
@@ -189,6 +222,11 @@ def main() -> int:
     parser.add_argument("--version", required=True)
     parser.add_argument("--output", type=Path, default=Path("dist"))
     parser.add_argument(
+        "--source-revision",
+        default="main",
+        help="immutable Git revision used for packaged README image URLs",
+    )
+    parser.add_argument(
         "--project-root",
         type=Path,
         default=Path(__file__).resolve().parent.parent,
@@ -200,6 +238,7 @@ def main() -> int:
         args.project_root.resolve(),
         args.output.resolve(),
         args.version,
+        args.source_revision,
     )
     print(archive)
     return 0


### PR DESCRIPTION
Rewrite relative README image paths only in the packaged add-in, using absolute raw GitHub URLs pinned to the exact source commit.

Keep repository documentation unchanged while making all ten images available when the packaged README is opened locally.